### PR TITLE
docs: clarify PR description guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,8 @@ git push -u origin <branch-name>
 gh pr create --title "Title" --body "Description"
 ```
 
-**NOTE**: PR descriptions should be short and concise. Do not include a "Test Plan" section - PRs are automatically tested in CI and do not need manual testing instructions beyond that.
+**NOTE**: PR descriptions should be short and concise. Do not include a "Test Plan" section - PRs are automatically
+tested in CI and do not need manual testing instructions beyond that.
 
 **NOTE**: Do not include "Generated with Claude Code" or similar AI attribution in PR descriptions.
 


### PR DESCRIPTION
Adds guidance that PR descriptions should be short and should not include a Test Plan section, since PRs are automatically tested in CI.