### PR TITLE
feat(nix): add cargo audit check with pinned advisory-db

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,9 +13,13 @@
       url = "github:emrldnix/wrangler";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, crane, rust-overlay, wrangler }:
+  outputs = { self, nixpkgs, flake-utils, crane, rust-overlay, wrangler, advisory-db }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -99,6 +103,12 @@
           rust-test = craneLib.cargoTest (commonArgs // {
             cargoArtifacts = craneLib.buildDepsOnly commonArgs;
           });
+
+          # Run cargo audit with Crane
+          rust-audit = craneLib.cargoAudit {
+            inherit (commonArgs) src;
+            inherit advisory-db;
+          };
         };
 
         # Packages


### PR DESCRIPTION
Adds a new `rust-audit` check that runs `cargo audit` to detect security vulnerabilities in dependencies.

## Implementation

- Added `advisory-db` as a pinned flake input from rustsec/advisory-db
- Created `rust-audit` check using `craneLib.cargoAudit`
- The advisory database is tracked as a flake input for reproducibility and easy updates