### PR TITLE
chore(nix): include webapp build in flake checks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -170,6 +170,9 @@
             inherit (commonArgs) src;
             inherit advisory-db;
           };
+
+          # Build webapp with wasm
+          webapp-build = webapp;
         };
 
         # Packages


### PR DESCRIPTION
Add the webapp build to the checks section in flake.nix so that `nix flake check` verifies the webapp builds successfully alongside other checks.

This ensures the WASM webapp build is validated as part of the standard Nix flake check workflow.