### PR TITLE
feat: optimize WASM builds for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,10 @@ name = "bayes-engine"
 [workspace.dependencies]
 dioxus = "0.6"
 wasm-bindgen = "0.2"
+
+[profile.release]
+opt-level = "z"     # Optimize for size
+lto = "fat"         # Enable full Link-Time Optimization for maximum size reduction
+codegen-units = 1   # Better optimization at the cost of compile time
+strip = true        # Strip symbols from binary
+panic = "abort"     # Reduce binary size by removing panic unwinding code

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -11,3 +11,6 @@ dioxus = { workspace = true }
 dioxus-web = "0.6"
 wasm-bindgen = { workspace = true }
 console_error_panic_hook = "0.1"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-bulk-memory", "--enable-mutable-globals", "--enable-sign-ext", "--enable-nontrapping-float-to-int"]

--- a/nix/build-webapp.sh
+++ b/nix/build-webapp.sh
@@ -33,7 +33,7 @@ ln -sf "$(command -v esbuild)" "$HOME/.cache/worker-build/esbuild-$ESBUILD_PLATF
 echo "Building client WASM..."
 mkdir -p assets/pkg
 cd client
-wasm-pack build --target web --out-dir ../assets/pkg --no-typescript --mode no-install
+wasm-pack build --release --target web --out-dir ../assets/pkg --no-typescript --mode no-install
 cd ..
 
 # Copy static HTML and CSS to assets


### PR DESCRIPTION
Significantly reduces WASM binary sizes through aggressive optimization techniques.

## Changes

### Cargo Profile Optimizations
- **opt-level = "z"**: Optimize specifically for binary size
- **lto = "fat"**: Enable full Link-Time Optimization for maximum size reduction
- **codegen-units = 1**: Single codegen unit for better cross-function optimization
- **strip = true**: Strip debug symbols from binaries
- **panic = "abort"**: Remove panic unwinding code

### WASM-specific Optimizations
- Configure wasm-pack to use `-Oz` optimization level
- Enable required WASM features: bulk-memory, mutable-globals, sign-ext, nontrapping-float-to-int
- Build client with `--release` flag

## Size Comparison

### Before
```
Build Size Report
  Server WASM:               402KiB
  Client WASM:               512KiB
  Server JS:                  18KiB
  Client JS:                  56KiB
  JS Snippets:                25KiB (8 files)
  HTML:                        467B
  CSS:                       1.3KiB
---
  Total WASM:                913KiB
  Total JS:                   98KiB
  Total Static:              1.8KiB
  Total:                    1012KiB
```

### After
```
Build Size Report
  Server WASM:               282KiB
  Client WASM:               329KiB
  Server JS:                  20KiB
  Client JS:                  59KiB
  JS Snippets:                25KiB (8 files)
  HTML:                        467B
  CSS:                       1.3KiB
---
  Total WASM:                611KiB
  Total JS:                  103KiB
  Total Static:              1.8KiB
  Total:                     715KiB
```

## Results

- **Server WASM**: 402KiB → 282KiB (**-30%**)
- **Client WASM**: 512KiB → 329KiB (**-36%**)
- **Total WASM**: 913KiB → 611KiB (**-33%**)
- **Overall**: 1012KiB → 715KiB (**-29%**)

**Total size reduction: 297KiB (29% smaller)**