### PR TITLE
Add routing with homepage and organized tests page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
  "dioxus",
+ "dioxus-router",
  "dioxus-web",
  "gloo-net",
  "gloo-timers",
@@ -567,6 +568,34 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-wasm",
+]
+
+[[package]]
+name = "dioxus-router"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7266a76fc9e4a91f56499d1d1aecfff7168952b6627a6008b4e9748d6bf863e4"
+dependencies = [
+ "dioxus-cli-config",
+ "dioxus-history",
+ "dioxus-lib",
+ "dioxus-router-macro",
+ "rustversion",
+ "tracing",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
+name = "dioxus-router-macro"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2743ffb79e9a7d33d779c87d6deea2a6c047d0736012f95d63b909b83f0a6fd2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "slab",
+ "syn",
 ]
 
 [[package]]
@@ -2344,6 +2373,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 dioxus = { workspace = true }
 dioxus-web = "0.6"
+dioxus-router = "0.6"
 wasm-bindgen = { workspace = true }
 console_error_panic_hook = "0.1"
 gloo-net = "0.6"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,4 +1,5 @@
 use dioxus::prelude::*;
+use dioxus_router::prelude::*;
 use gloo_net::http::Request;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -17,6 +18,14 @@ struct UppercaseResponse {
     result: String,
 }
 
+#[derive(Clone, Routable, Debug, PartialEq)]
+enum Route {
+    #[route("/")]
+    Home {},
+    #[route("/tests")]
+    Tests {},
+}
+
 // WASM entry point for the Dioxus web app (client-side)
 // This function is called from JavaScript in the browser
 #[wasm_bindgen]
@@ -27,6 +36,25 @@ pub fn hydrate() {
 
 #[component]
 fn App() -> Element {
+    rsx! {
+        Router::<Route> {}
+    }
+}
+
+#[component]
+fn Home() -> Element {
+    rsx! {
+        div { class: "home-container",
+            h1 { class: "home-title", "bayes engine" }
+            nav { class: "home-nav",
+                Link { to: Route::Tests {}, "View Tests" }
+            }
+        }
+    }
+}
+
+#[component]
+fn Tests() -> Element {
     // Use Rust signal for reactive state management
     let mut count = use_signal(|| 0);
     let mut input_text = use_signal(String::new);
@@ -34,88 +62,98 @@ fn App() -> Element {
     let mut is_loading = use_signal(|| false);
 
     rsx! {
-        div { class: "container",
-            h1 { "Hello World!" }
-            p { "This is a Dioxus WASM app running on CloudFlare Workers" }
-
-            HyperLogLogDemo {}
-
-            div { class: "counter-section",
-                p { class: "counter-label", "Click Counter:" }
-                p { class: "counter-display", "{count}" }
-                button {
-                    class: "counter-button",
-                    onclick: move |_| count += 1,
-                    "Click Me!"
-                }
+        div { class: "tests-container",
+            nav { class: "tests-nav",
+                Link { to: Route::Home {}, "← Back to Home" }
             }
 
-            div { class: "uppercase-section",
-                h2 { "Uppercase REST API Demo" }
-                p { "Enter text and click the button to convert it to uppercase using the server API" }
+            h1 { "Tests & Demos" }
 
-                input {
-                    class: "text-input",
-                    r#type: "text",
-                    placeholder: "Enter text here...",
-                    value: "{input_text}",
-                    oninput: move |evt| input_text.set(evt.value().clone()),
+            div { class: "test-grid",
+                div { class: "test-box",
+                    h2 { "Click Counter" }
+                    p { class: "counter-label", "Click Counter:" }
+                    p { class: "counter-display", "{count}" }
+                    button {
+                        class: "counter-button",
+                        onclick: move |_| count += 1,
+                        "Click Me!"
+                    }
                 }
 
-                button {
-                    class: "uppercase-button",
-                    disabled: is_loading(),
-                    onclick: move |_| {
-                        let text = input_text().clone();
-                        spawn(async move {
-                            is_loading.set(true);
+                div { class: "test-box",
+                    HyperLogLogDemo {}
+                }
 
-                            let request_body = UppercaseRequest { text };
+                div { class: "test-box",
+                    h2 { "Uppercase REST API Demo" }
+                    p { "Enter text and click the button to convert it to uppercase using the server API" }
 
-                            match Request::post("/api/uppercase")
-                                .json(&request_body)
-                            {
-                                Ok(req) => {
-                                    match req.send().await {
-                                        Ok(response) => {
-                                            match response.json::<UppercaseResponse>().await {
-                                                Ok(data) => {
-                                                    uppercase_result.set(data.result);
-                                                }
-                                                Err(_) => {
-                                                    uppercase_result.set("Error parsing response".to_string());
+                    input {
+                        class: "text-input",
+                        r#type: "text",
+                        placeholder: "Enter text here...",
+                        value: "{input_text}",
+                        oninput: move |evt| input_text.set(evt.value().clone()),
+                    }
+
+                    button {
+                        class: "uppercase-button",
+                        disabled: is_loading(),
+                        onclick: move |_| {
+                            let text = input_text().clone();
+                            spawn(async move {
+                                is_loading.set(true);
+
+                                let request_body = UppercaseRequest { text };
+
+                                match Request::post("/api/uppercase")
+                                    .json(&request_body)
+                                {
+                                    Ok(req) => {
+                                        match req.send().await {
+                                            Ok(response) => {
+                                                match response.json::<UppercaseResponse>().await {
+                                                    Ok(data) => {
+                                                        uppercase_result.set(data.result);
+                                                    }
+                                                    Err(_) => {
+                                                        uppercase_result.set("Error parsing response".to_string());
+                                                    }
                                                 }
                                             }
-                                        }
-                                        Err(_) => {
-                                            uppercase_result.set("Error sending request".to_string());
+                                            Err(_) => {
+                                                uppercase_result.set("Error sending request".to_string());
+                                            }
                                         }
                                     }
+                                    Err(_) => {
+                                        uppercase_result.set("Error creating request".to_string());
+                                    }
                                 }
-                                Err(_) => {
-                                    uppercase_result.set("Error creating request".to_string());
-                                }
-                            }
 
-                            is_loading.set(false);
-                        });
-                    },
-                    if is_loading() { "Converting..." } else { "Convert to Uppercase" }
-                }
+                                is_loading.set(false);
+                            });
+                        },
+                        if is_loading() { "Converting..." } else { "Convert to Uppercase" }
+                    }
 
-                if !uppercase_result().is_empty() {
-                    div { class: "result-display",
-                        p { class: "result-label", "Result:" }
-                        p { class: "result-text", "{uppercase_result}" }
+                    if !uppercase_result().is_empty() {
+                        div { class: "result-display",
+                            p { class: "result-label", "Result:" }
+                            p { class: "result-text", "{uppercase_result}" }
+                        }
                     }
                 }
             }
 
-            p {
-                "Built with "
-                a { href: "https://dioxuslabs.com/", target: "_blank", "Dioxus" }
-                " and "
-                a { href: "https://github.com/cloudflare/workers-rs", target: "_blank", "workers-rs" }
+            footer { class: "tests-footer",
+                p {
+                    "Built with "
+                    a { href: "https://dioxuslabs.com/", target: "_blank", "Dioxus" }
+                    " and "
+                    a { href: "https://github.com/cloudflare/workers-rs", target: "_blank", "workers-rs" }
+                }
             }
         }
     }

--- a/e2e_tests/src/main.rs
+++ b/e2e_tests/src/main.rs
@@ -60,6 +60,14 @@ pub async fn run(driver: &WebDriver, webapp_url: &str) -> Result<()> {
     println!("Waiting for page to load and hydrate...");
     tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
 
+    // Navigate to the tests page by clicking the link
+    println!("Navigating to tests page...");
+    let tests_link = driver.find(By::Css("a[href='/tests']")).await?;
+    tests_link.click().await?;
+
+    // Wait for navigation and re-render
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
     // Test 1: Counter functionality
     println!("Testing counter button...");
     let counter_display = driver.find(By::Css(".counter-display")).await?;

--- a/public/style.css
+++ b/public/style.css
@@ -1,30 +1,129 @@
+/* Global styles */
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    min-height: 100vh;
+}
+
+/* Home page styles */
+.home-container {
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
     min-height: 100vh;
-    margin: 0;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-}
-
-.container {
-    background: white;
-    padding: 3rem;
-    border-radius: 1rem;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
     text-align: center;
 }
 
-.counter-section {
-    margin: 2rem 0;
-    padding: 1.5rem;
-    background: #f8f9fa;
-    border-radius: 0.5rem;
+.home-title {
+    font-size: 5rem;
+    font-weight: 700;
+    color: white;
+    margin: 0;
+    text-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
 }
 
+.home-nav {
+    margin-top: 3rem;
+}
+
+.home-nav a {
+    display: inline-block;
+    background: white;
+    color: #667eea;
+    text-decoration: none;
+    padding: 1rem 2.5rem;
+    border-radius: 2rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+    transition: transform 0.2s, box-shadow 0.2s;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+}
+
+.home-nav a:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
+}
+
+/* Tests page styles */
+.tests-container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 2rem;
+    min-height: 100vh;
+}
+
+.tests-nav {
+    margin-bottom: 2rem;
+}
+
+.tests-nav a {
+    display: inline-block;
+    background: white;
+    color: #667eea;
+    text-decoration: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.5rem;
+    font-weight: 600;
+    transition: transform 0.2s, box-shadow 0.2s;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.tests-nav a:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+}
+
+.tests-container > h1 {
+    color: white;
+    font-size: 3rem;
+    margin: 0 0 2rem 0;
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+    text-align: center;
+}
+
+/* Responsive grid layout for test boxes */
+.test-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 2rem;
+    margin-bottom: 2rem;
+}
+
+@media (max-width: 768px) {
+    .test-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* Individual test box styling */
+.test-box {
+    background: white;
+    padding: 2rem;
+    border-radius: 1rem;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.test-box:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 15px 40px rgba(0, 0, 0, 0.3);
+}
+
+.test-box h2 {
+    margin-top: 0;
+    color: #667eea;
+    font-size: 1.5rem;
+    border-bottom: 2px solid #f0f0f0;
+    padding-bottom: 0.75rem;
+    margin-bottom: 1.5rem;
+}
+
+/* Counter section styles */
 .counter-label {
-    font-size: 1.2rem;
+    font-size: 1rem;
     font-weight: 600;
     color: #495057;
     margin: 0 0 1rem 0;
@@ -57,4 +156,213 @@ body {
 
 .counter-button:active {
     transform: translateY(0);
+}
+
+/* HyperLogLog section styles */
+.hyperloglog-section h2 {
+    /* Inherits from .test-box h2 */
+}
+
+.hyperloglog-section p {
+    color: #495057;
+    line-height: 1.6;
+    margin-bottom: 1rem;
+}
+
+.controls {
+    display: flex;
+    gap: 1rem;
+    margin: 1.5rem 0;
+    flex-wrap: wrap;
+}
+
+.control-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.control-group label {
+    font-weight: 600;
+    color: #495057;
+}
+
+.control-group select {
+    padding: 0.5rem 1rem;
+    border: 2px solid #e9ecef;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: border-color 0.2s;
+}
+
+.control-group select:focus {
+    outline: none;
+    border-color: #667eea;
+}
+
+.control-button {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    transition: transform 0.2s, box-shadow 0.2s;
+    box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
+}
+
+.control-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.5);
+}
+
+.control-button:active {
+    transform: translateY(0);
+}
+
+.reset-button {
+    background: linear-gradient(135deg, #dc3545 0%, #c82333 100%);
+}
+
+.stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+    margin: 1.5rem 0;
+}
+
+.stat-item {
+    background: #f8f9fa;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    text-align: center;
+}
+
+.stat-label {
+    font-size: 0.9rem;
+    color: #6c757d;
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+}
+
+.stat-value {
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #495057;
+}
+
+.stat-value.good {
+    color: #28a745;
+}
+
+.stat-value.warning {
+    color: #ffc107;
+}
+
+.stat-value.error {
+    color: #dc3545;
+}
+
+.info {
+    background: #e7f3ff;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    border-left: 4px solid #667eea;
+}
+
+.info p {
+    margin: 0;
+    color: #495057;
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+/* Uppercase section styles */
+.text-input {
+    width: 100%;
+    padding: 0.75rem;
+    border: 2px solid #e9ecef;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    margin-bottom: 1rem;
+    box-sizing: border-box;
+    transition: border-color 0.2s;
+}
+
+.text-input:focus {
+    outline: none;
+    border-color: #667eea;
+}
+
+.uppercase-button {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    transition: transform 0.2s, box-shadow 0.2s;
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+    width: 100%;
+    margin-bottom: 1rem;
+}
+
+.uppercase-button:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(102, 126, 234, 0.6);
+}
+
+.uppercase-button:active:not(:disabled) {
+    transform: translateY(0);
+}
+
+.uppercase-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.result-display {
+    background: #f8f9fa;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    margin-top: 1rem;
+}
+
+.result-label {
+    font-weight: 600;
+    color: #495057;
+    margin: 0 0 0.5rem 0;
+}
+
+.result-text {
+    font-size: 1.2rem;
+    color: #667eea;
+    margin: 0;
+    word-break: break-all;
+}
+
+/* Footer styles */
+.tests-footer {
+    text-align: center;
+    padding: 2rem 0;
+    color: white;
+}
+
+.tests-footer p {
+    margin: 0;
+}
+
+.tests-footer a {
+    color: white;
+    text-decoration: underline;
+    font-weight: 600;
+}
+
+.tests-footer a:hover {
+    text-decoration: none;
 }


### PR DESCRIPTION
## Changes

- Add dioxus-router for client-side navigation
- Create clean homepage displaying "bayes engine"
- Move all test widgets to `/tests` route
- Organize tests in responsive grid layout with individual cards
- Update e2e tests to navigate from homepage to tests page

## UI Improvements

- Responsive grid layout that adapts to screen size
- Floating cards with hover effects for each test widget
- Improved visual hierarchy and spacing
- Maintains existing purple gradient theme