### PR TITLE
fix: make PR preview links open in new tab

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,7 @@ jobs:
           script: |
             const prNumber = context.issue.number;
             const previewUrl = '${{ steps.deploy-preview.outputs.deployment-url }}';
-            const body = `### 🚀 PR Preview Deployed\n\nYour preview deployment is ready!\n\n**Preview URL:** ${previewUrl}\n\nThis preview will be automatically deleted when the PR is closed or merged.`;
+            const body = `### 🚀 PR Preview Deployed\n\nYour preview deployment is ready!\n\n**Preview URL:** <a href="${previewUrl}" target="_blank" rel="noopener noreferrer">${previewUrl}</a>\n\nThis preview will be automatically deleted when the PR is closed or merged.`;
 
             // Check if we already commented
             const comments = await github.rest.issues.listComments({


### PR DESCRIPTION
Updates the PR preview URL in the GitHub workflow to use an HTML anchor tag with `target="_blank"` and `rel="noopener noreferrer"` so that preview links open in a new tab.

This improves the user experience when clicking PR preview links from GitHub comments.