### PR TITLE
feat: add pre-commit hook for nix flake check and e2e tests

### DIFF
--- a/nix/pre-commit-hook.sh
+++ b/nix/pre-commit-hook.sh
@@ -14,7 +14,7 @@ run_check() {
   local name="$2"
   
   echo "Running $name..."
-  if "$cmd" > "$TMP_OUTPUT" 2>&1; then
+  if bash -c "$cmd" > "$TMP_OUTPUT" 2>&1; then
     echo "$name passed ✓"
     return 0
   else


### PR DESCRIPTION
Adds a pre-commit hook script that runs 'nix flake check' and 'nix run .#run-e2e-tests'. The hook captures all stdout+stderr and only displays output on failure, keeping successful runs quiet.