### PR TITLE
chore: configure custom domain bayes.lemmih.com

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy
+          command: deploy --env production
 
       - name: Deploy to CloudFlare Workers (PR Preview)
         if: github.event_name == 'pull_request' && steps.check-deployment.outputs.deploy == 'true'
@@ -75,7 +75,8 @@ jobs:
         with:
           script: |
             const prNumber = context.issue.number;
-            const previewUrl = '${{ steps.deploy-preview.outputs.deployment-url }}';
+            // Construct preview URL manually since routes are not applied to PR previews
+            const previewUrl = `https://bayes-engine-pr-${prNumber}.lemmih.workers.dev`;
             const body = `### 🚀 PR Preview Deployed\n\nYour preview deployment is ready!\n\n**Preview URL:** <a href="${previewUrl}" target="_blank" rel="noopener noreferrer">${previewUrl}</a>\n\nThis preview will be automatically deleted when the PR is closed or merged.`;
 
             // Check if we already commented

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,11 +2,6 @@ name = "bayes-engine"
 main = "result/worker/worker.js"
 compatibility_date = "2024-10-01"
 
-# Custom domain configuration
-routes = [
-  { pattern = "bayes.lemmih.com/*", zone_name = "lemmih.com" }
-]
-
 [build]
 command = "nix build .#webapp"
 
@@ -22,6 +17,16 @@ not_found_handling = "single-page-application"
 [[hyperdrive]]
 binding = "HYPERDRIVE"
 id = "a88d53af1e344d80bdd1ab8f88692b14"
+
+# Production environment - includes custom domain routes
+[env.production]
+routes = [
+  { pattern = "bayes.lemmih.com/*", zone_name = "lemmih.com" }
+]
+
+[env.production.assets]
+directory = "result/assets"
+not_found_handling = "single-page-application"
 
 # E2E testing environment - uses pre-compiled files without running build
 [env.e2e]


### PR DESCRIPTION
Configures wrangler.toml to deploy the worker on the custom domain bayes.lemmih.com.

## Changes
- Added routes configuration in wrangler.toml to handle requests for bayes.lemmih.com

## CloudFlare Configuration Required
- Create a DNS record for bayes.lemmih.com (CNAME or A record with proxy enabled)
- The route will be automatically configured on deployment