### PR TITLE
fix(config): mark bayes.lemmih.com as custom domain

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,7 +21,7 @@ id = "a88d53af1e344d80bdd1ab8f88692b14"
 # Production environment - includes custom domain routes
 [env.production]
 routes = [
-  { pattern = "bayes.lemmih.com/*", zone_name = "lemmih.com" }
+  { pattern = "bayes.lemmih.com/*", zone_name = "lemmih.com", custom_domain = true }
 ]
 
 [env.production.assets]


### PR DESCRIPTION
Marks the bayes.lemmih.com route as a custom domain by adding the `custom_domain = true` flag to the route configuration in wrangler.toml.