### PR TITLE
fix(config): remove wildcard from custom domain pattern

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,7 +21,7 @@ id = "a88d53af1e344d80bdd1ab8f88692b14"
 # Production environment - includes custom domain routes
 [env.production]
 routes = [
-  { pattern = "bayes.lemmih.com/*", zone_name = "lemmih.com", custom_domain = true }
+  { pattern = "bayes.lemmih.com", zone_name = "lemmih.com", custom_domain = true }
 ]
 
 [env.production.assets]


### PR DESCRIPTION
Removes the wildcard (`/*`) from the custom domain pattern. The pattern should be `bayes.lemmih.com` instead of `bayes.lemmih.com/*` for proper custom domain routing.