### PR TITLE
fix: add Hyperdrive binding to production and e2e environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,7 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Run e2e tests
+        env:
+          # Provides local Postgres connection for Hyperdrive emulation in wrangler dev
+          CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE: ${{ secrets.NEON_DATABASE_URL }}
         run: nix run .#run-e2e-tests

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -24,6 +24,10 @@ routes = [
   { pattern = "bayes.lemmih.com", zone_name = "lemmih.com", custom_domain = true }
 ]
 
+[[env.production.hyperdrive]]
+binding = "HYPERDRIVE"
+id = "a88d53af1e344d80bdd1ab8f88692b14"
+
 [env.production.assets]
 directory = "result/assets"
 not_found_handling = "single-page-application"
@@ -31,6 +35,12 @@ not_found_handling = "single-page-application"
 # E2E testing environment - uses pre-compiled files without running build
 [env.e2e]
 # No build command - assumes result/ directory already exists with compiled files
+
+# Hyperdrive for e2e tests - requires CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE
+# environment variable to be set (e.g., from GitHub secrets)
+[[env.e2e.hyperdrive]]
+binding = "HYPERDRIVE"
+id = "a88d53af1e344d80bdd1ab8f88692b14"
 
 [env.e2e.assets]
 directory = "result/assets"


### PR DESCRIPTION
## Summary

- Add `[[env.production.hyperdrive]]` binding so production deployments can connect to the database
- Add `[[env.e2e.hyperdrive]]` binding for e2e test environment

## Problem

The Hyperdrive binding was only defined at the top level of `wrangler.toml`, but CloudFlare Workers **does not inherit** top-level bindings into environment-specific deployments. This caused the production deployment at bayes.lemmih.com to fail database connections, resulting in "Error parsing messages" errors.

## Fix

Explicitly add the Hyperdrive binding to both `env.production` and `env.e2e` sections.