### PR TITLE
chore(deps): upgrade wasmi from 0.51 to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2897,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.51.1"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4f6b71d5cb04a4615b9a8a2e522ba284c491ad847afd9e905d89be15e3efc0"
+checksum = "e1fda10642ea9ba8141d50976b2b3a02d30511baa4b938383b9fa823b35d4138"
 dependencies = [
  "spin",
  "wasmi_collections",
@@ -2911,27 +2911,27 @@ dependencies = [
 
 [[package]]
 name = "wasmi_collections"
-version = "0.51.1"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a4a11fa090c4d742e5a77dbbc8efbbe1aa151db7335ca6850232e6cafbb1023"
+checksum = "a67707a7d9eaf65181751b39cf46a003acc2ae1fef7917add38c3ced4b2eb868"
 dependencies = [
  "string-interner",
 ]
 
 [[package]]
 name = "wasmi_core"
-version = "0.51.1"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3e422fc1f4df78c9ded6ed48c4ca6d1f55f4609f04c99962fc07532e4db61d"
+checksum = "ca9ad2a338c53920b3fd427c2122219fd315dc09044dbda58606259d7854cbed"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmi_ir"
-version = "0.51.1"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fe9f9f1747ec81644e764c4dc798f063f5d54a495f0a3b4a375bce9af65399"
+checksum = "27a6079b0597d3793aedbd2a2c0eea595476acabd797df9bba9270fbe319fad0"
 dependencies = [
  "wasmi_core",
 ]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,7 +21,7 @@ web-sys = { version = "0.3", features = ["File", "HtmlInputElement"] }
 rand = { version = "0.9", default-features = false, features = ["small_rng"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wasmi = "0.51"
+wasmi = "1.0"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Oz", "--enable-bulk-memory", "--enable-mutable-globals", "--enable-sign-ext", "--enable-nontrapping-float-to-int"]

--- a/client/src/wasm_executor.rs
+++ b/client/src/wasm_executor.rs
@@ -233,18 +233,11 @@ async fn execute_wasm_module(wasm_bytes: &[u8]) -> Result<String, String> {
     // Create a linker (for imports)
     let linker = Linker::new(&engine);
 
-    // Instantiate the module (without running start function)
-    // Note: We use the deprecated `instantiate` method because we want to avoid
-    // running the start function. The recommended `instantiate_and_start` would
-    // automatically run the start function.
-    #[allow(deprecated)]
-    let pre_instance = linker
-        .instantiate(&mut store, &module)
+    // Instantiate the module
+    // Note: If the module has a start function, it will be executed automatically.
+    let instance = linker
+        .instantiate_and_start(&mut store, &module)
         .map_err(|e| format!("Failed to instantiate module: {}", e))?;
-
-    let instance = pre_instance
-        .ensure_no_start(&mut store)
-        .map_err(|e| format!("Module has start function, which is not supported: {}", e))?;
 
     // Try to call the add function as a test
     if let Ok(add_func) = instance.get_typed_func::<(i32, i32), i32>(&store, "add") {


### PR DESCRIPTION
## Summary

- Upgrade wasmi WebAssembly interpreter from version 0.51 to 1.0.8
- Replace deprecated `Linker::instantiate` API with `instantiate_and_start`
- Simplify WASM module instantiation code in wasm_executor.rs

## Changes

The wasmi 1.0 release removed the deprecated `Linker::instantiate` method and `InstancePre::ensure_no_start`. The new `instantiate_and_start` method is now the recommended way to instantiate modules.

**Note:** Modules with start functions are now executed automatically rather than being rejected. This aligns with the standard WebAssembly instantiation behavior.