### PR TITLE
fix: remove runtime schema ALTERs that break repository listing

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -320,20 +320,6 @@ async fn ensure_schema(client: &tokio_postgres::Client) -> Result<()> {
             UNIQUE(wasm_file_id, function_name)
         );
 
-        ALTER TABLE wasm_files
-            ADD COLUMN IF NOT EXISTS r2_key TEXT;
-
-        ALTER TABLE wasm_functions
-            ADD COLUMN IF NOT EXISTS submitted_updates BIGINT NOT NULL DEFAULT 0;
-
-        ALTER TABLE wasm_functions
-            ADD COLUMN IF NOT EXISTS lowest_hash TEXT;
-
-        ALTER TABLE wasm_functions
-            ADD COLUMN IF NOT EXISTS lowest_seed TEXT;
-
-        ALTER TABLE wasm_functions
-            ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
         ",
         )
         .await


### PR DESCRIPTION
## Summary
- remove `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` statements from `ensure_schema`
- keep only `CREATE TABLE IF NOT EXISTS` in runtime schema checks

## Why
Production currently fails listing repositories with:
`Failed listing repositories: Failed to ensure schema: db error`

The failure started after adding runtime ALTERs in `ensure_schema`. Running ALTERs on every request can fail in production due to DB privileges/constraints and blocks read endpoints.

## Validation
- `cargo check -p server`
