### PR TITLE
fix: remove runtime ALTERs from ensure_schema (write-path safety)

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -320,20 +320,6 @@ async fn ensure_schema(client: &tokio_postgres::Client) -> Result<()> {
             UNIQUE(wasm_file_id, function_name)
         );
 
-        ALTER TABLE wasm_files
-            ADD COLUMN IF NOT EXISTS r2_key TEXT;
-
-        ALTER TABLE wasm_functions
-            ADD COLUMN IF NOT EXISTS submitted_updates BIGINT NOT NULL DEFAULT 0;
-
-        ALTER TABLE wasm_functions
-            ADD COLUMN IF NOT EXISTS lowest_hash TEXT;
-
-        ALTER TABLE wasm_functions
-            ADD COLUMN IF NOT EXISTS lowest_seed TEXT;
-
-        ALTER TABLE wasm_functions
-            ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
         ",
         )
         .await


### PR DESCRIPTION
## Summary
- remove runtime `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` statements from `ensure_schema`
- keep `ensure_schema` focused on `CREATE TABLE IF NOT EXISTS`

## Why
`main` still executes runtime ALTERs in write paths (`/api/test-results`, `/api/ci-upload`, `/api/messages`).
On Neon/Hyperdrive these DDL operations can fail at request time and break API writes.

## Validation
- `cargo check -p server`
