### PR TITLE
fix(server): remove runtime schema ensure from /api/test-results

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1344,7 +1344,6 @@ async fn handle_submit_test_result(mut req: Request, env: Env) -> Result<Respons
     };
 
     let client = connect_to_db(&env).await?;
-    ensure_schema(&client).await?;
 
     let mut function_id = body.function_id;
     let mut row = client


### PR DESCRIPTION
## Summary
- remove runtime `ensure_schema` call from `handle_submit_test_result`

## Why
`POST /api/test-results` is currently failing in production with HTTP 500 because runtime schema DDL in request path fails in this environment.

This endpoint should perform data updates only, not attempt schema DDL.

## Validation
- `cargo check -p server`
