### PR TITLE
ci: test WASM upload against local server instead of production

### DIFF
--- a/.github/workflows/ci-wasm-upload-poc.yml
+++ b/.github/workflows/ci-wasm-upload-poc.yml
@@ -133,7 +133,8 @@ jobs:
             -H "Authorization: Bearer ${{ steps.oidc.outputs.oidc_token }}" \
             -F "file=@${{ steps.wasm.outputs.wasm_file }}" \
             -F "declared_sha256=${{ steps.wasm.outputs.wasm_sha256 }}" \
-            -F "version=${GITHUB_SHA}")
+            -F "version=${GITHUB_SHA}" \
+            -F "dry_run=true")
 
           if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
             echo "Upload succeeded with HTTP $HTTP_CODE"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1614,12 +1614,20 @@ async fn handle_ci_upload(mut req: Request, env: Env) -> Result<Response> {
 
     let event_allowed = claims.event_name == "push"
         || claims.event_name == "workflow_dispatch"
-        || claims.event_name == "pull_request";
+        || (claims.event_name == "pull_request" && dry_run);
     if !event_allowed {
         return error_response(
             403,
             "event_not_allowed",
-            "Only push/workflow_dispatch/pull_request events are accepted",
+            "Only push/workflow_dispatch events are accepted, or pull_request when dry_run=true",
+        );
+    }
+
+    if claims.event_name == "pull_request" && !dry_run {
+        return error_response(
+            403,
+            "dry_run_required",
+            "pull_request uploads must set dry_run=true",
         );
     }
 


### PR DESCRIPTION
## Summary

- Stop testing CI upload workflow against production (`bayes.lemmih.com`)
- Spin up local wrangler dev server during CI and test against it
- Use `NEON_DATABASE_URL` secret for database connectivity
- Use wrangler's built-in local R2 simulation

## Changes

- Use local wrangler dev server (`localhost:8787`) for upload tests
- Connect to PostgreSQL via `NEON_DATABASE_URL` secret
- Remove "Wait for preview deployment" step (no longer needed)
- Simplify upload step (no retry loop for stale previews)
- Add cleanup step to stop wrangler server
- Pin runner to `ubuntu-24.04`
- Drop `workflow_dispatch` trigger
- Update workflow summary to reflect local testing

## Benefits

- Production database issues no longer break main branch CI
- Better isolation between CI and production
- Full OIDC auth validation still works (GitHub tokens are valid anywhere)

Fixes #84