### PR TITLE
feat: reduce default HLL bit size from 12 to 5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ Lower hash = more leading zeros = rarer event = higher estimate
 
 **Key parameters:**
 
-- `HLL_BITS = 12` (default) -> 4096 registers
+- `HLL_BITS = 5` (default) -> 32 registers
 - `MAX_HLL_BITS = 20` -> up to 1M registers
 - More bits = better precision, more storage
 
@@ -248,7 +248,7 @@ wasm_functions (
   repository_id BIGINT REFERENCES repositories(id),
   version_id BIGINT REFERENCES repository_versions(id),
   function_name TEXT NOT NULL,
-  hll_bits INTEGER DEFAULT 12,
+  hll_bits INTEGER DEFAULT 5,
   hll_hashes_json TEXT,  -- JSON array of min-hashes
   submitted_updates BIGINT DEFAULT 0,
   lowest_hash TEXT,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -388,7 +388,7 @@ fn RepoRunner(repository: String, latest_version: Option<String>) -> Element {
 
                         let hll = local_hll
                             .entry(executable.function_id)
-                            .or_insert_with(|| LocalHyperLogLog::new(12));
+                            .or_insert_with(|| LocalHyperLogLog::new(5));
                         if hll.add_hash(hash) {
                             improvements += 1;
                             let function_id = executable.function_id;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -18,7 +18,7 @@ const EXPECTED_OIDC_AUDIENCE: &str = "bayes-engine-ci-upload";
 const GITHUB_API_BASE: &str = "https://api.github.com";
 const REPLAY_TTL_SECS: u64 = 600;
 const MAX_UPLOAD_BYTES: usize = 10 * 1024 * 1024;
-const HLL_BITS: u8 = 12;
+const HLL_BITS: u8 = 5;
 const MAX_HLL_BITS: u8 = 20;
 
 static IN_MEMORY_REPLAY: Lazy<Mutex<HashMap<String, u64>>> =
@@ -330,7 +330,7 @@ async fn ensure_schema(client: &tokio_postgres::Client) -> Result<()> {
             repository_id BIGINT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
             version_id BIGINT NOT NULL REFERENCES repository_versions(id) ON DELETE CASCADE,
             function_name TEXT NOT NULL,
-            hll_bits INTEGER NOT NULL DEFAULT 12,
+            hll_bits INTEGER NOT NULL DEFAULT 5,
             hll_hashes_json TEXT NOT NULL,
             submitted_updates BIGINT NOT NULL DEFAULT 0,
             lowest_hash TEXT,


### PR DESCRIPTION
## Summary

- Reduces the default HyperLogLog bit size from 12 to 5
- This changes the number of buckets from 4096 (2^12) to 32 (2^5)
- Decreases storage requirements while maintaining reasonable cardinality estimation

## Changes

- `server/src/lib.rs`: Updated `HLL_BITS` constant and database schema default
- `client/src/lib.rs`: Updated client-side `LocalHyperLogLog` initialization
- `AGENTS.md`: Updated documentation to reflect the new default